### PR TITLE
feat: keep old error to be returned after max attempt occured

### DIFF
--- a/valkyrietry.go
+++ b/valkyrietry.go
@@ -2,6 +2,7 @@ package valkyrietry
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"time"
 )
@@ -70,12 +71,14 @@ func Do(ctx context.Context, f RetryFunc, options ...Option) error {
 		timer.Stop()
 	}()
 
+	var err error
+
 	for {
 		if currentAttempt > int(valkyrietry.Configuration.MaxRetryAttempts) {
-			return ErrMaxRetryAttemptsExceeded
+			return errors.Join(err, ErrMaxRetryAttemptsExceeded)
 		}
 
-		err := f()
+		err = f()
 
 		if err == nil {
 			return nil
@@ -118,13 +121,14 @@ func DoWithData[T any](ctx context.Context, f RetryFuncWithData[T], options ...O
 	}()
 
 	var response T
+	var err error
 
 	for {
 		if currentAttempt > int(valkyrietry.Configuration.MaxRetryAttempts) {
-			return response, ErrMaxRetryAttemptsExceeded
+			return response, errors.Join(err, ErrMaxRetryAttemptsExceeded)
 		}
 
-		response, err := f()
+		response, err = f()
 
 		if err == nil {
 			return response, nil

--- a/valkyrietry_test.go
+++ b/valkyrietry_test.go
@@ -41,7 +41,7 @@ func TestMaxRetryAttemptsExceeded(t *testing.T) {
 		WithMaxRetryAttempts(2),
 	)
 
-	if err == nil || err != ErrMaxRetryAttemptsExceeded {
+	if err == nil || !errors.Is(err, ErrMaxRetryAttemptsExceeded) {
 		t.Errorf("Expected ErrMaxRetryAttemptsExceeded, got %v", err)
 	}
 }


### PR DESCRIPTION
## Description
As the library user, we couldn't get the error that returned from the retryFunc when the max attempt occurred, so this PR will keep the last error to be joined and returned by the valkyrietry itself.

## Unit Test Check
![image](https://github.com/ruang-guru/valkyrietry/assets/29916319/49608589-854e-4b41-a353-4c1c26bb4a89)

## Before PR
![image](https://github.com/ruang-guru/valkyrietry/assets/29916319/49989ee6-ef5f-409c-b063-d8c5a7d643fa)

## After PR
![image](https://github.com/ruang-guru/valkyrietry/assets/29916319/c76a953c-11cb-451e-84ee-d121ea0d5673)

